### PR TITLE
To enable the clamav-freshclam to be added on cron

### DIFF
--- a/ClamAV2/start.sh
+++ b/ClamAV2/start.sh
@@ -15,9 +15,9 @@ if [[ -x "./clamav_daemon.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then
 	fi
 	HOUR_OFF=$(expr 24 / ${DEF_UPD_FREQ})
 	REFERENCE="${ARBITRARY_OFFSET} */${HOUR_OFF} * * * root /etc/init.d/clamav-freshclam no-daemon 2>&1" # ARBITRARY MINUTE every HOUR
-        ./clamav_daemon.sh &;
         echo "${REFERENCE}"
         echo "${REFERENCE}" >> /etc/cron.d/scan_cron
+        ./clamav_daemon.sh &
 fi
 
 if [[ -x "./queue_process.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then

--- a/ClamAV2/start.sh
+++ b/ClamAV2/start.sh
@@ -16,8 +16,8 @@ if [[ -x "./clamav_daemon.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then
 	HOUR_OFF=$(expr 24 / ${DEF_UPD_FREQ})
 	REFERENCE="${ARBITRARY_OFFSET} */${HOUR_OFF} * * * root /etc/init.d/clamav-freshclam no-daemon 2>&1" # ARBITRARY MINUTE every HOUR
         ./clamav_daemon.sh &;
-  echo "${REFERENCE}"
-  echo "${REFERENCE}" >> /etc/cron.d/scan_cron
+        echo "${REFERENCE}"
+        echo "${REFERENCE}" >> /etc/cron.d/scan_cron
 fi
 
 if [[ -x "./queue_process.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then

--- a/ClamAV2/start.sh
+++ b/ClamAV2/start.sh
@@ -15,7 +15,9 @@ if [[ -x "./clamav_daemon.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then
 	fi
 	HOUR_OFF=$(expr 24 / ${DEF_UPD_FREQ})
 	REFERENCE="${ARBITRARY_OFFSET} */${HOUR_OFF} * * * root /etc/init.d/clamav-freshclam no-daemon 2>&1" # ARBITRARY MINUTE every HOUR
-        ./clamav_daemon.sh &
+        ./clamav_daemon.sh &;
+  echo "${REFERENCE}"
+  echo "${REFERENCE}" >> /etc/cron.d/scan_cron
 fi
 
 if [[ -x "./queue_process.sh" && ("${MODE}" == "" || "${MODE}" == "av") ]]; then


### PR DESCRIPTION
I update some lines to enable the clamav-freshclam to be added on the cron(scan_cron). We noticed this on our containers that the virus database definitions on our VPSA containers is not updating. We already tested this changes on our test environment and its working properly